### PR TITLE
add bech32 encode and decode methods

### DIFF
--- a/cmd/noisd/bech32.go
+++ b/cmd/noisd/bech32.go
@@ -6,19 +6,34 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/types/bech32"
 )
 
+// Cmd creates a main CLI command
+func Bech32Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bech32",
+		Short: "Tool for helping encoding/decoding bech32 addresses",
+		RunE:  client.ValidateCmd,
+	}
+
+	cmd.AddCommand(Bech32EncodeCmd())
+	cmd.AddCommand(Bech32DecodeCmd())
+
+	return cmd
+}
+
 func Bech32EncodeCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "bech32-encode [prefix] [bech32 string]",
+		Use:   "encode [prefix] [bech32 string]",
 		Short: "Encode any bech32 or hex string to the [prefix] address",
 		Long: `Encode any bech32 or hex string to the [prefix] address
 Example:
-	noisd debug bech32-encode nois cosmos18afy9mwgrmtpsl4vhgfvq0r3knm4tw2yftqlpg
-	noisd debug bech32-encode nois 3F5242EDC81ED6187EACBA12C03C71B4F755B944
-	noisd debug bech32-encode noisvaloper nois18afy9mwgrmtpsl4vhgfvq0r3knm4tw2ycra4ds
-	noisd debug bech32-encode nois noisvaloper18afy9mwgrmtpsl4vhgfvq0r3knm4tw2yer055y
+	noisd bech32 encode nois cosmos18afy9mwgrmtpsl4vhgfvq0r3knm4tw2yftqlpg
+	noisd bech32 encode nois 3F5242EDC81ED6187EACBA12C03C71B4F755B944
+	noisd bech32 encode noisvaloper nois18afy9mwgrmtpsl4vhgfvq0r3knm4tw2ycra4ds
+	noisd bech32 encode nois noisvaloper18afy9mwgrmtpsl4vhgfvq0r3knm4tw2yer055y
 	`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -53,16 +68,18 @@ Example:
 	return cmd
 }
 
+var flagHexFormat = "hex"
+
 func Bech32DecodeCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "bech32-decode [bech32 string]",
+		Use:   "decode [bech32 string]",
 		Short: "Decode any bech32 or hex string raw bytes",
 		Long: `Decode any bech32 or hex string raw bytes
 Example:
-	noisd debug bech32-decode cosmos18afy9mwgrmtpsl4vhgfvq0r3knm4tw2yftqlpg
-	noisd debug bech32-decode 3F5242EDC81ED6187EACBA12C03C71B4F755B944
-	noisd debug bech32-decode nois18afy9mwgrmtpsl4vhgfvq0r3knm4tw2ycra4ds
-	noisd debug bech32-decode noisvaloper18afy9mwgrmtpsl4vhgfvq0r3knm4tw2yer055y
+	noisd bech32 decode cosmos18afy9mwgrmtpsl4vhgfvq0r3knm4tw2yftqlpg
+	noisd bech32 decode 3F5242EDC81ED6187EACBA12C03C71B4F755B944
+	noisd bech32 decode nois18afy9mwgrmtpsl4vhgfvq0r3knm4tw2ycra4ds
+	noisd bech32 decode noisvaloper18afy9mwgrmtpsl4vhgfvq0r3knm4tw2yer055y
 	`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -81,11 +98,19 @@ Example:
 					return err
 				}
 			}
+			format := "%d\n"
+			hex, _ := cmd.Flags().GetBool(flagHexFormat)
+			if err != nil {
+				return err
+			}
 
-			fmt.Printf("%d\n", bz)
+			if hex {
+				format = "%X\n"
+			}
+			fmt.Printf(format, bz)
 			return nil
 		},
 	}
-
+	cmd.Flags().Bool(flagHexFormat, false, "Output raw bytes in hex format")
 	return cmd
 }

--- a/cmd/noisd/bech32.go
+++ b/cmd/noisd/bech32.go
@@ -66,7 +66,6 @@ Example:
 	`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			addrString := args[0]
 
 			// bytes of the parsed address

--- a/cmd/noisd/bech32.go
+++ b/cmd/noisd/bech32.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cosmos/cosmos-sdk/types/bech32"
+)
+
+func Bech32EncodeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bech32-encode [prefix] [bech32 string]",
+		Short: "Encode any bech32 or hex string to the [prefix] address",
+		Long: `Encode any bech32 or hex string to the [prefix] address
+Example:
+	noisd debug bech32-encode nois cosmos18afy9mwgrmtpsl4vhgfvq0r3knm4tw2yftqlpg
+	noisd debug bech32-encode nois 3F5242EDC81ED6187EACBA12C03C71B4F755B944
+	noisd debug bech32-encode noisvaloper nois18afy9mwgrmtpsl4vhgfvq0r3knm4tw2ycra4ds
+	noisd debug bech32-encode nois noisvaloper18afy9mwgrmtpsl4vhgfvq0r3knm4tw2yer055y
+	`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			bech32prefix := args[0]
+
+			addrString := args[1]
+
+			// bytes of the parsed address
+			var bz []byte
+			var err error
+
+			// try decoding hex first
+			bz, err = hex.DecodeString(addrString)
+			if err != nil {
+				// try decoding any bech32 address
+				_, bz, err = bech32.DecodeAndConvert(addrString)
+				if err != nil {
+					return err
+				}
+			}
+
+			// convert to desired bech32 prefix
+			bech32Addr, err := bech32.ConvertAndEncode(bech32prefix, bz)
+			if err != nil {
+				return err
+			}
+			cmd.Println(bech32Addr)
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func Bech32DecodeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bech32-decode [bech32 string]",
+		Short: "Decode any bech32 or hex string raw bytes",
+		Long: `Decode any bech32 or hex string raw bytes
+Example:
+	noisd debug bech32-decode cosmos18afy9mwgrmtpsl4vhgfvq0r3knm4tw2yftqlpg
+	noisd debug bech32-decode 3F5242EDC81ED6187EACBA12C03C71B4F755B944
+	noisd debug bech32-encode nois18afy9mwgrmtpsl4vhgfvq0r3knm4tw2ycra4ds
+	noisd debug bech32-encode noisvaloper18afy9mwgrmtpsl4vhgfvq0r3knm4tw2yer055y
+	`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			addrString := args[0]
+
+			// bytes of the parsed address
+			var bz []byte
+			var err error
+
+			// try decoding hex first
+			bz, err = hex.DecodeString(addrString)
+			if err != nil {
+				// try decoding any bech32 address
+				_, bz, err = bech32.DecodeAndConvert(addrString)
+				if err != nil {
+					return err
+				}
+			}
+
+			fmt.Printf("%d\n", bz)
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/noisd/bech32.go
+++ b/cmd/noisd/bech32.go
@@ -61,8 +61,8 @@ func Bech32DecodeCmd() *cobra.Command {
 Example:
 	noisd debug bech32-decode cosmos18afy9mwgrmtpsl4vhgfvq0r3knm4tw2yftqlpg
 	noisd debug bech32-decode 3F5242EDC81ED6187EACBA12C03C71B4F755B944
-	noisd debug bech32-encode nois18afy9mwgrmtpsl4vhgfvq0r3knm4tw2ycra4ds
-	noisd debug bech32-encode noisvaloper18afy9mwgrmtpsl4vhgfvq0r3knm4tw2yer055y
+	noisd debug bech32-decode nois18afy9mwgrmtpsl4vhgfvq0r3knm4tw2ycra4ds
+	noisd debug bech32-decode noisvaloper18afy9mwgrmtpsl4vhgfvq0r3knm4tw2yer055y
 	`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/noisd/root.go
+++ b/cmd/noisd/root.go
@@ -93,9 +93,6 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 }
 
 func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
-	debugCmd := debug.Cmd()
-	debugCmd.AddCommand(Bech32EncodeCmd())
-	debugCmd.AddCommand(Bech32DecodeCmd())
 
 	rootCmd.AddCommand(
 		InitCmd(app.ModuleBasics, app.DefaultNodeHome),
@@ -104,9 +101,10 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 		genutilcli.ValidateGenesisCmd(app.ModuleBasics),
 		AddGenesisAccountCmd(app.DefaultNodeHome),
 		tmcli.NewCompletionCmd(rootCmd, true),
-		debugCmd,
+		debug.Cmd(),
 		config.Cmd(),
 		PrepareGenesisCmd(app.DefaultNodeHome, app.ModuleBasics),
+		Bech32Cmd(),
 	)
 
 	ac := appCreator{

--- a/cmd/noisd/root.go
+++ b/cmd/noisd/root.go
@@ -93,7 +93,6 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 }
 
 func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
-
 	rootCmd.AddCommand(
 		InitCmd(app.ModuleBasics, app.DefaultNodeHome),
 		genutilcli.CollectGenTxsCmd(banktypes.GenesisBalancesIterator{}, app.DefaultNodeHome),

--- a/cmd/noisd/root.go
+++ b/cmd/noisd/root.go
@@ -93,6 +93,10 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 }
 
 func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
+	debugCmd := debug.Cmd()
+	debugCmd.AddCommand(Bech32EncodeCmd())
+	debugCmd.AddCommand(Bech32DecodeCmd())
+
 	rootCmd.AddCommand(
 		InitCmd(app.ModuleBasics, app.DefaultNodeHome),
 		genutilcli.CollectGenTxsCmd(banktypes.GenesisBalancesIterator{}, app.DefaultNodeHome),
@@ -100,7 +104,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 		genutilcli.ValidateGenesisCmd(app.ModuleBasics),
 		AddGenesisAccountCmd(app.DefaultNodeHome),
 		tmcli.NewCompletionCmd(rootCmd, true),
-		debug.Cmd(),
+		debugCmd,
 		config.Cmd(),
 		PrepareGenesisCmd(app.DefaultNodeHome, app.ModuleBasics),
 	)


### PR DESCRIPTION
Encode examples:

```
> noisd bech32 encode nois cosmos18afy9mwgrmtpsl4vhgfvq0r3knm4tw2yftqlpg
nois18afy9mwgrmtpsl4vhgfvq0r3knm4tw2ycra4ds

> noisd bech32 encode nois 3F5242EDC81ED6187EACBA12C03C71B4F755B944
nois18afy9mwgrmtpsl4vhgfvq0r3knm4tw2ycra4ds

> noisd bech32 encode noisvaloper nois18afy9mwgrmtpsl4vhgfvq0r3knm4tw2ycra4ds
noisvaloper18afy9mwgrmtpsl4vhgfvq0r3knm4tw2yer055y

> noisd bech32 encode nois noisvaloper18afy9mwgrmtpsl4vhgfvq0r3knm4tw2yer055y
nois18afy9mwgrmtpsl4vhgfvq0r3knm4tw2ycra4ds
```

Decode examples:
```
> noisd bech32 decode cosmos18afy9mwgrmtpsl4vhgfvq0r3knm4tw2yftqlpg
[63 82 66 237 200 30 214 24 126 172 186 18 192 60 113 180 247 85 185 68]

> noisd bech32 decode cosmos18afy9mwgrmtpsl4vhgfvq0r3knm4tw2yftqlpg --hex 
3F5242EDC81ED6187EACBA12C03C71B4F755B944

> noisd bech32 decode 3F5242EDC81ED6187EACBA12C03C71B4F755B944
[63 82 66 237 200 30 214 24 126 172 186 18 192 60 113 180 247 85 185 68]

> noisd bech32 decode noisvaloper18afy9mwgrmtpsl4vhgfvq0r3knm4tw2yer055y
[63 82 66 237 200 30 214 24 126 172 186 18 192 60 113 180 247 85 185 68]

```